### PR TITLE
fix: remove ProtBitSetButNoneFound

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -318,9 +318,9 @@ impl From<CanErrorFrame> for CanError {
                     can_error.protocol_violations.push(vtype);
                 }
             }
-            // CAN_ERR_PROT is set, but no protocol violations were found.
+            // CAN_ERR_PROT is set, but no protocol violations were found
             if can_error.protocol_violations.is_empty() {
-                // Fallback to unspecified in this case.
+                // Fallback to unspecified in this case
                 can_error.protocol_violations.push(ViolationType::Unspecified);
             }
             match Location::try_from(frame.data()[3]) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -318,9 +318,10 @@ impl From<CanErrorFrame> for CanError {
                     can_error.protocol_violations.push(vtype);
                 }
             }
-            // CAN_ERR_PROT is set, but no protocol violations were found
+            // CAN_ERR_PROT is set, but no protocol violations were found.
             if can_error.protocol_violations.is_empty() {
-                can_error.decoding_failures.push(CanErrorDecodingFailure::ProtBitSetButNoneFound);
+                // Fallback to unspecified in this case.
+                can_error.protocol_violations.push(ViolationType::Unspecified);
             }
             match Location::try_from(frame.data()[3]) {
                 Ok(location) => can_error.location = Some(location),
@@ -663,8 +664,6 @@ pub enum CanErrorDecodingFailure {
     NotEnoughData(u8),
     /// The error type `ControllerProblem` was indicated but none of the data[1] bits decoded to any problem
     CtrlBitSetButNoneFound,
-    /// the error type `ProtocolViolation` was indicated but none of the data[2] bits decoded to a valid type
-    ProtBitSetButNoneFound,
     /// A location was specified for a ProtocolViolation, but the location
     /// was not valid.
     InvalidProtocolViolationLocation,
@@ -682,7 +681,6 @@ impl fmt::Display for CanErrorDecodingFailure {
             UnknownErrorType(_) => "unknown error type",
             NotEnoughData(_) => "not enough data",
             CtrlBitSetButNoneFound => "controller problem bit set, but no problems found",
-            ProtBitSetButNoneFound => "protocol problem bit set, but no violations found",
             InvalidProtocolViolationLocation => "not a valid protocol violation location",
             InvalidTransceiverError => "not a valid transceiver error",
         };

--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -82,10 +82,10 @@ use rt::can_ctrlmode;
 pub use rt::CanState;
 
 /// A result for Netlink errors.
-type NlResult<T> = Result<T, NlError>;
+pub type NlResult<T> = Result<T, NlError>;
 
 /// A Netlink error from an info query
-type NlInfoError = NlError<Rtm, Ifinfomsg>;
+pub type NlInfoError = NlError<Rtm, Ifinfomsg>;
 
 /// CAN bit-timing parameters
 pub type CanBitTiming = rt::can_bittiming;


### PR DESCRIPTION
Fixes the bug discussed in the main PR: https://github.com/socketcan-rs/socketcan-rs/pull/82#issuecomment-2874057567 (`ViolationType::Unspecified` was not correctly parsed)